### PR TITLE
improve names of virtual ports

### DIFF
--- a/touchosc2midi/configuration.py
+++ b/touchosc2midi/configuration.py
@@ -9,7 +9,7 @@ import logging
 
 log = logging.getLogger(__name__)
 
-VIRT_MIDI_PORT = "TouchOSC Bridge"
+CLIENT = "TouchOSC Bridge"
 
 
 class ConfigurationError(Exception):
@@ -74,8 +74,8 @@ def configure_ioports(backend, virtual=True, mido_in=None, mido_out=None):
     if virtual:
         try:
             # we have to init with dummy callback, there seems to be a bug in mido
-            midi_in = backend.open_input(VIRT_MIDI_PORT, virtual=True, callback=lambda x: x)
-            midi_out = backend.open_output(VIRT_MIDI_PORT, virtual=True)
+            midi_in = backend.open_input("In", client_name=CLIENT, virtual=True, callback=lambda x: x)
+            midi_out = backend.open_output("Out", client_name=CLIENT, virtual=True)
         except ImportError:
             log.error("Cannot open virtual IOports. Make sure, rtmidi is available"
                       "or choose another backend.")


### PR DESCRIPTION
This changes the names of the virtual ports so they are easier to identify:

```console
patch@patchcube:~ $ midiwala list
Ports:
    Launchpad Pro MK3 : LPProMK3 MIDI [ 28:0] <->
    Launchpad Pro MK3 : LPProMK3 DIN  [ 28:1] <->
    Launchpad Pro MK3 : LPProMK3 DAW  [ 28:2] <->
    MicroMonsta 2     : MIDI 1        [ 24:0] <->
    Midi Through      : Port-0        [ 14:0] <->
    TouchOSC Bridge   : In            [131:0] <--
    TouchOSC Bridge   : Out           [132:0] -->
Connections:
    -- no connections --
```

This enables easy connections, like so:
```console
patch@patchcube:~ $ midiwala connect TouchOSC Monsta
Connected TouchOSC Bridge:Out [132:0] --> MicroMonsta 2:MIDI 1 [24:0]

patch@patchcube:~ $ midiwala connect Launchpad TouchOSC
Connected Launchpad Pro MK3:LPProMK3 MIDI [28:0] --> TouchOSC Bridge:In [131:0]
```
